### PR TITLE
Implement waitlist, labels, and Geist font

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }


### PR DESCRIPTION
## Summary
- allow visitors to join a wait list when a screening is full
- add `<label>` elements and a `<fieldset>` to the RSVP form for accessibility
- apply the custom Geist font to body text

## Testing
- `npm run lint` *(fails: `next` not found)*