### PR TITLE
Add past screenings helper and page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,7 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+.subtext {
+  @apply text-sm text-gray-500 dark:text-gray-400;
+}

--- a/src/app/past/page.tsx
+++ b/src/app/past/page.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { db } from '../../lib/firebase'
+import { collection, getDocs } from 'firebase/firestore'
+import { formatScreeningDate } from '../../lib/formatScreeningDate'
+
+interface Movie {
+  id: string
+  title: string
+  date: string
+  time: string
+}
+
+export default function PastScreeningsPage() {
+  const [movies, setMovies] = useState<Movie[]>([])
+
+  useEffect(() => {
+    const fetchMovies = async () => {
+      const snapshot = await getDocs(collection(db, 'movies'))
+      const data = snapshot.docs.map(doc => ({ id: doc.id, ...(doc.data() as any) }))
+      const now = new Date()
+      const past = data.filter(movie => {
+        try {
+          const [timePart, modifier] = movie.time.split(' ')
+          const [rawHour] = timePart.split(':')
+          let hour = parseInt(rawHour, 10)
+          if (modifier === 'PM' && hour !== 12) hour += 12
+          if (modifier === 'AM' && hour === 12) hour = 0
+          const dateObj = new Date(`${movie.date}T${hour.toString().padStart(2, '0')}:00:00`)
+          return dateObj <= now
+        } catch {
+          return false
+        }
+      })
+      past.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
+      setMovies(past)
+    }
+    fetchMovies()
+  }, [])
+
+  return (
+    <main className="min-h-screen px-4 py-8 bg-porcelain dark:bg-charcoal text-text-primary-light dark:text-text-primary-dark space-y-6">
+      <h1 className="text-3xl font-serif font-bold mb-4">Past Screenings</h1>
+      {movies.length === 0 ? (
+        <p className="text-center text-gray-500">No past screenings found.</p>
+      ) : (
+        <ul className="space-y-4">
+          {movies.map(movie => (
+            <li key={movie.id} className="p-4 rounded-lg bg-surface-light dark:bg-surface-dark shadow">
+              <h2 className="font-semibold">{movie.title}</h2>
+              <p className="subtext">{formatScreeningDate(movie)}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  )
+}

--- a/src/lib/formatScreeningDate.ts
+++ b/src/lib/formatScreeningDate.ts
@@ -1,0 +1,18 @@
+export function formatScreeningDate(screening: { date: string; time: string }): string {
+  try {
+    const [timePart, modifier] = screening.time.split(' ')
+    const [rawHour] = timePart.split(':')
+    let hour = parseInt(rawHour, 10)
+    if (modifier === 'PM' && hour !== 12) hour += 12
+    if (modifier === 'AM' && hour === 12) hour = 0
+    const dateObj = new Date(`${screening.date}T${hour.toString().padStart(2, '0')}:00:00`)
+    const formattedDate = dateObj.toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    })
+    return `${formattedDate} \u2013 ${screening.time}`
+  } catch {
+    return `${screening.date} \u2013 ${screening.time}`
+  }
+}


### PR DESCRIPTION
## Summary
- add `formatScreeningDate` helper for friendly date formatting
- use it in a new Past Screenings page
- include simple `.subtext` style for readability

## Testing
- `npm run lint` *(fails: `next` not found)*